### PR TITLE
Enable radial pendulum launch from center

### DIFF
--- a/main.js
+++ b/main.js
@@ -85,9 +85,6 @@ function computeLevel(){
     s.ballRadius = Math.max(5*dpr, thickness * 0.23);
     resetRunState(shape);
   } else if (shape==='pendulum'){
-    s.pendulum.length = Math.min(s.W,s.H)*0.3;
-    s.pendulum.angle = Math.PI/3;
-    s.pendulum.vel = 0;
     ui.drawMode.checked = true;
     s.ballRadius = Math.max(5*dpr, 6*dpr);
     resetRunState(shape);
@@ -153,12 +150,24 @@ function step(ts){
     const b = s.balls[0];
     if (b){
       b.px = b.x; b.py = b.y;
-      const p = s.pendulum;
-      p.vel += -p.gravity * Math.sin(p.angle) * dtFull;
-      p.vel *= (1 - p.damping*dtFull);
-      p.angle += p.vel * dtFull;
-      b.x = s.CX + Math.sin(p.angle) * p.length;
-      b.y = s.CY + Math.cos(p.angle) * p.length;
+      if (s.launched){
+        const dx = s.CX - b.x, dy = s.CY - b.y;
+        const dist = Math.hypot(dx,dy) || 1;
+        const ax = dx/dist * s.G;
+        const ay = dy/dist * s.G;
+        b.vx += ax * dtFull;
+        b.vy += ay * dtFull;
+        const damp = s.pendulum.damping;
+        b.vx *= (1 - damp*dtFull);
+        b.vy *= (1 - damp*dtFull);
+        b.x += b.vx*dtFull;
+        b.y += b.vy*dtFull;
+        const margin = b.r + 4*dpr;
+        if (b.x < margin){ b.x = margin; b.vx = Math.abs(b.vx); playBounce(); }
+        if (b.x > s.W - margin){ b.x = s.W - margin; b.vx = -Math.abs(b.vx); playBounce(); }
+        if (b.y < margin){ b.y = margin; b.vy = Math.abs(b.vy); playBounce(); }
+        if (b.y > s.H - margin){ b.y = s.H - margin; b.vy = -Math.abs(b.vy); playBounce(); }
+      }
       b.trail.push({x:b.x,y:b.y});
       if (ui.drawMode.checked){
         let hue, sat=88, light=60;

--- a/ui.js
+++ b/ui.js
@@ -93,18 +93,13 @@ export function resetRunState(shapeMode){
     spawnX = s.CX;
     spawnY = Math.max(18*s.dpr, 10);
   } else if (mode==='pendulum'){
-    const p = s.pendulum;
-    spawnX = s.CX + Math.sin(p.angle)*p.length;
-    spawnY = s.CY + Math.cos(p.angle)*p.length;
+    spawnX = s.CX;
+    spawnY = s.CY;
   }
   const b = makeBall(spawnX, spawnY, 0, 0);
   b.trail.push({x:b.x,y:b.y});
   s.balls.push(b);
-  if (mode==='pendulum'){
-    s.aiming=false; s.launched=true;
-  } else {
-    s.aiming=true; s.launched=false;
-  }
+  s.aiming=true; s.launched=false;
   s.finished=false; s.elMsg.style.display='none';
 }
 


### PR DESCRIPTION
## Summary
- Launch pendulum mode balls from the center and let users aim and shoot
- Apply gravity toward the center for pendulum swings with damping and edge bounces
- Simplify pendulum reset so aiming is required before launch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb430727908327ba780c2542247699