### PR TITLE
Adjust pendulum ball spawn to orbit center

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -94,7 +94,7 @@ export function resetRunState(shapeMode){
     spawnY = Math.max(18*s.dpr, 10);
   } else if (mode==='pendulum'){
     spawnX = s.CX;
-    spawnY = s.CY;
+    spawnY = s.CY + s.pendulum.length * s.dpr;
   }
   const b = makeBall(spawnX, spawnY, 0, 0);
   b.trail.push({x:b.x,y:b.y});


### PR DESCRIPTION
## Summary
- spawn pendulum ball below central force to allow curved swing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb452e080c8327a8a9fe22ef4f3565