### PR TITLE
feat: make ball slowdown adjustable

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,11 @@
       </div>
 
       <div class="row">
+        <label for="ballSlow">Geschw.-Verlust (pro 5 s): <span id="ballSlowVal" class="kbd">1%</span></label>
+        <input id="ballSlow" type="range" min="0" max="10" step="0.1" value="1"/>
+      </div>
+
+      <div class="row">
         <label><input id="multi" type="checkbox"/> Multiball</label>
       </div>
 

--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ const state = {
   balls:[],
   bounceCount:0,
   audioCtx:null, masterGain:null,
-  pendulum:{angle:Math.PI/4, vel:0, length:120, damping:0.15, gravity:2.5}
+    pendulum:{angle:Math.PI/4, vel:0, length:120, damping:0, gravity:2.5}
 };
 
 globalThis.state = state;

--- a/ui.js
+++ b/ui.js
@@ -14,6 +14,8 @@ export const ui = {
   gravityVal: document.getElementById('gravityVal'),
   trailLen: document.getElementById('trailLen'),
   trailLenVal: document.getElementById('trailLenVal'),
+  ballSlow: document.getElementById('ballSlow'),
+  ballSlowVal: document.getElementById('ballSlowVal'),
   multi: document.getElementById('multi'),
   drawMode: document.getElementById('drawMode'),
   pendulumLen: document.getElementById('pendulumLen'),
@@ -43,6 +45,11 @@ export function syncLabels(){
   if (ui.shotSpeedVal && ui.shotSpeed){ ui.shotSpeedVal.textContent = ui.shotSpeed.value; }
   if (ui.gravityVal && ui.gravity){ ui.gravityVal.textContent = ui.gravity.value; }
   if (ui.trailLenVal && ui.trailLen){ ui.trailLenVal.textContent = ui.trailLen.value; }
+  if (ui.ballSlowVal && ui.ballSlow){ ui.ballSlowVal.textContent = ui.ballSlow.value + '%'; }
+  if (ui.ballSlow && globalThis.state){
+    const pct = parseFloat(ui.ballSlow.value);
+    globalThis.state.pendulum.damping = pct>0 ? -Math.log(1 - pct/100)/5 : 0;
+  }
   if (ui.pendulumLenVal && ui.pendulumLen){ ui.pendulumLenVal.textContent = ui.pendulumLen.value; }
   if (ui.pendulumLen && globalThis.state){ globalThis.state.pendulum.length = +ui.pendulumLen.value; }
   if (ui.pitchShiftVal && ui.pitchShift){ ui.pitchShiftVal.textContent = ui.pitchShift.value; }
@@ -131,7 +138,7 @@ export async function startGame(){
 }
 
 export function setupUI(){
-  [ui.numRings, ui.openWidth, ui.shotSpeed, ui.gravity, ui.trailLen, ui.pendulumLen, ui.pitchShift, ui.toneDur, ui.shape, ui.drawColorMode]
+  [ui.numRings, ui.openWidth, ui.shotSpeed, ui.gravity, ui.trailLen, ui.ballSlow, ui.pendulumLen, ui.pitchShift, ui.toneDur, ui.shape, ui.drawColorMode]
     .filter(Boolean)
     .forEach(el=>{
       el.addEventListener('input', syncLabels);


### PR DESCRIPTION
## Summary
- add speed-loss slider to options menu
- wire UI to update ball damping and apply to pendulum physics
- set default to 1% speed loss every 5 seconds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb4a255ec88327861d473cd69aa7e2