### PR TITLE
UI adjustments for fullscreen stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,15 +17,14 @@
   #paintCanvas { z-index: 2; pointer-events:none; }
 
   .hud {
-    position:absolute; left:12px; top:12px; display:flex; gap:8px; flex-wrap:wrap; align-items:center;
+    position:absolute; left:50%; transform:translateX(-50%); display:flex; flex-direction:column; gap:4px; align-items:center;
     background:var(--glass); border:1px solid var(--line); border-radius:10px; padding:8px 10px; backdrop-filter: blur(8px);
     font-size:13px; z-index:3;
   }
-  .hud .stat { padding:4px 8px; border-radius:8px; background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.08); }
-  .hud button {
-    appearance:none; border:1px solid rgba(255,255,255,.2); background:#121823; color:var(--fg); padding:6px 10px; border-radius:8px; cursor:pointer; font-size:13px;
+  .hud .stat { padding:4px 8px; border-radius:8px; background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.08); position:relative; }
+  .hud .stat-btn {
+    position:absolute; inset:0; background:transparent; border:none; cursor:pointer; opacity:0;
   }
-  .hud button:hover { filter:brightness(1.1); }
 
   .msg {
     position:absolute; left:50%; top:50%; transform:translate(-50%,-50%);
@@ -71,10 +70,8 @@
   <canvas id="c"></canvas>
 
   <div class="hud hidden" id="hud">
-    <span class="stat">Layers: <b id="layersLeft">10</b></span>
-    <span class="stat">Bounces: <b id="bounces">0</b></span>
-    <button id="backMenu">Zurück ins Menü</button>
-    <button id="reset">Neu starten</button>
+    <span class="stat">Layers: <b id="layersLeft">10</b><button id="reset" class="stat-btn"></button></span>
+    <span class="stat">Bounces: <b id="bounces">0</b><button id="backMenu" class="stat-btn"></button></span>
   </div>
 
   <div id="msg" class="msg">Alle Layers entfernt! Tippe/Klick in die Mitte und schieße erneut.</div>

--- a/main.js
+++ b/main.js
@@ -33,6 +33,20 @@ const state = {
 
 globalThis.state = state;
 
+function updateHudPosition(){
+  const s = state;
+  let topPx;
+  if (ui.shape.value === 'circle'){
+    const edgeGap = Math.max(22*s.dpr,16);
+    const outerR = Math.min(s.W,s.H)/2 - edgeGap;
+    topPx = s.CY + outerR + 8*s.dpr;
+  } else {
+    const bottomGapPx = 24*s.dpr;
+    topPx = s.H - bottomGapPx + 8*s.dpr;
+  }
+  s.hud.style.top = (topPx / s.dpr) + 'px';
+}
+
 function calibrateMM(){
   const mmDiv = document.getElementById('mmCal');
   const wCss = mmDiv.getBoundingClientRect().width;
@@ -45,6 +59,7 @@ function resize(){
   if (w===state.W && h===state.H) return;
   state.W=w; state.H=h; main.width=w; main.height=h; paint.width=w; paint.height=h; state.CX=w/2; state.CY=h/2;
   calibrateMM();
+  updateHudPosition();
 }
 window.addEventListener('resize', resize, {passive:true});
 
@@ -122,6 +137,7 @@ function computeLevel(){
   s.ringsLeft = (ui.shape.value==='circle' ? s.rings.length : s.lines.length);
   s.elLayers.textContent = String(s.ringsLeft);
   s.bounceCount = 0; s.elBounces.textContent = '0';
+  updateHudPosition();
 }
 
 globalThis.resize = resize;


### PR DESCRIPTION
## Summary
- Stack layer and bounce counters at bottom center
- Replace menu and restart buttons with invisible click areas on stats
- Position HUD relative to outer layer for consistent placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc0811672c83279550a8f3f4baf0c0