### PR TITLE
Fix line mode collision and spawn placement

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ const state = {
   balls:[],
   bounceCount:0,
   audioCtx:null, masterGain:null,
+  spawnY:0,
     pendulum:{angle:Math.PI/4, vel:0, length:120, damping:0, gravity:2.5}
 };
 
@@ -111,18 +112,16 @@ function computeLevel(){
     s.elMsg.style.display='none';
     return;
   } else {
-    const topGapPx = 24*dpr;
+    const spawnY = s.H * 0.3;
+    s.spawnY = spawnY;
+    const topGapPx = spawnY + 40*dpr;
     const bottomGapPx = 24*dpr;
     const avail = s.H - topGapPx - bottomGapPx;
-    const gapRatio = 0.33;
-    const spanFactor = (s.NUM_RINGS + (s.NUM_RINGS-1)*gapRatio);
-    let thickness = Math.max(10*dpr, avail / (spanFactor+0.0001));
-    let gap = thickness * gapRatio;
-    const totalNeeded = s.NUM_RINGS*thickness + (s.NUM_RINGS-1)*gap;
-    if (totalNeeded > avail){
-      const scale = avail / totalNeeded;
-      thickness *= scale; gap *= scale;
-    }
+    const maxThickness = 8*dpr;
+    let thickness = Math.min(maxThickness, avail / (s.NUM_RINGS*2));
+    thickness = Math.max(4*dpr, thickness);
+    const totalLinesHeight = thickness * s.NUM_RINGS;
+    const gap = (avail - totalLinesHeight) / Math.max(1, s.NUM_RINGS-1);
     const openPx = Math.max(6, s.OPEN_VAL * s.pxPerMM);
     for (let i=0;i<s.NUM_RINGS;i++){
       const yCenter = topGapPx + thickness/2 + i*(thickness+gap);

--- a/physics.js
+++ b/physics.js
@@ -87,11 +87,12 @@ export function processRingForBall_Lines(b){
   if (idx >= lines.length) return;
   const L = lines[idx];
   const yTop = L.y - L.halfT;
-  const yBot = L.y + L.halfT;
   const left = L.openX - L.openW/2;
   const right= L.openX + L.openW/2;
-  const prevAboveTop = (b.py <= yTop - b.r), nowBelowTop = (b.y  >= yTop + b.r);
-  const prevAboveMid = (b.py <= L.y), nowBelowMid = (b.y >= L.y);
+  const prevAboveTop = (b.py + b.r <= yTop);
+  const nowBelowTop = (b.y  + b.r >= yTop);
+  const prevAboveMid = (b.py <= L.y);
+  const nowBelowMid = (b.y >= L.y);
   if (prevAboveTop && nowBelowTop){
     if (!(b.x >= left && b.x <= right)){
       b.y = yTop - b.r - 0.01;

--- a/rendering.js
+++ b/rendering.js
@@ -33,7 +33,7 @@ export function draw(){
   const markerR = Math.max(2, 2.5*dpr);
   const mode = ui.shape.value;
   if (mode==='lines'){
-    ctx.arc(CX, Math.max(18*dpr, 10), markerR, 0, Math.PI*2);
+    ctx.arc(CX, s.spawnY || Math.max(18*dpr, 10), markerR, 0, Math.PI*2);
   } else {
     ctx.arc(CX, CY, markerR, 0, Math.PI*2);
   }
@@ -114,13 +114,13 @@ export function draw(){
   }
 
   if (aiming && !launched){
-    const ax=aimX-(ui.shape.value==='circle'?CX:CX), ay=aimY-(ui.shape.value==='circle'?CY:Math.max(18*dpr,10));
+    const baseY = (ui.shape.value==='circle'?CY:(s.spawnY || Math.max(18*dpr,10)));
+    const ax=aimX-CX, ay=aimY-baseY;
     const len=Math.hypot(ax,ay);
     const maxPull=Math.min(W,H)*0.46*0.55;
     const pull=Math.min(len, maxPull);
     const dirx=ax/(len||1), diry=ay/(len||1);
-    const baseX = (ui.shape.value==='circle'?CX:CX);
-    const baseY = (ui.shape.value==='circle'?CY:Math.max(18*dpr,10));
+    const baseX = CX;
     const tipX=baseX+dirx*pull, tipY=baseY+diry*pull;
 
     ctx.save();

--- a/ui.js
+++ b/ui.js
@@ -84,7 +84,8 @@ export function pointerMove(e){ const s=globalThis.state; if(!s.aiming) return; 
 export function pointerUp(){
   const s=globalThis.state;
   if (!s.aiming) return;
-  const ax=s.aimX-s.CX, ay=s.aimY-s.CY;
+  const baseY = (ui.shape.value==='circle'? s.CY : s.spawnY);
+  const ax=s.aimX-s.CX, ay=s.aimY-baseY;
   const len=Math.hypot(ax,ay);
   if (len>0.0001){
     const maxPull=Math.min(s.W,s.H)*0.46*0.55;
@@ -105,7 +106,7 @@ export function resetRunState(shapeMode){
   const mode = (shapeMode||ui.shape.value);
   if (mode==='lines'){
     spawnX = s.CX;
-    spawnY = Math.max(18*s.dpr, 10);
+    spawnY = s.spawnY || s.H*0.3;
   } else if (mode==='pendulum'){
     spawnX = s.CX;
     spawnY = s.CY + s.pendulum.length * s.dpr;


### PR DESCRIPTION
## Summary
- Ensure balls collide properly with line bars
- Make line obstacles thinner and place ball spawn in upper-third of screen
- Align aiming and rendering with new spawn point

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc6c4d1e688327b3ac83be1e64f388