### PR TITLE
Show HUD in line mode and fix bounce counter

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -29,6 +29,8 @@ export function resetToneSeq(){
   else { seqState.idx=0; seqState.dir=1; }
   melodyState.idx=0;
 }
+
+export function resetBounceCount(){ bounceCount = 0; }
 function nextScaleIndex(){
   const ui=globalThis.state.ui;
   const N=scaleSemitones.length;

--- a/index.html
+++ b/index.html
@@ -26,9 +26,6 @@
     font-size:13px; z-index:3;
   }
   .hud .stat { padding:4px 8px; border-radius:8px; background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.08); position:relative; }
-  .hud .stat-btn {
-    position:absolute; inset:0; background:transparent; border:none; cursor:pointer; opacity:0;
-  }
 
   .msg {
     position:absolute; left:50%; top:50%; transform:translate(-50%,-50%);
@@ -74,11 +71,13 @@
   <canvas id="c"></canvas>
 
   <div class="hud hidden" id="hud">
-    <span class="stat">Layers: <b id="layersLeft">10</b><button id="reset" class="stat-btn"></button></span>
-    <span class="stat">Bounces: <b id="bounces">0</b><button id="backMenu" class="stat-btn"></button></span>
+    <span class="stat">Layers: <b id="layersLeft">10</b></span>
+    <span class="stat">Bounces: <b id="bounces">0</b></span>
+    <button id="reset" class="stat">⟳</button>
+    <button id="backMenu" class="stat">⚙️</button>
   </div>
 
-  <div id="msg" class="msg">Alle Layers entfernt! Tippe/Klick in die Mitte und schieße erneut.</div>
+  <div id="msg" class="msg"></div>
 </div>
 
 <div id="startScreen">

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 import { draw, hslToRgb, rgbString, rgbaString } from "./rendering.js";
 import { angleNorm, makeBall, processRingForBall_Circle, processRingForBall_Lines } from './physics.js';
-import { initAudio, playBounce, resetToneSeq } from './audio.js';
+import { initAudio, playBounce, resetToneSeq, resetBounceCount } from './audio.js';
 import { ui, setupUI, resetRunState } from './ui.js';
 
 const main = document.getElementById('c');
@@ -36,8 +36,21 @@ globalThis.state = state;
 
 function updateHudPosition(){
   const s = state;
+  const shape = ui.shape.value;
+  if (shape === 'lines'){
+    s.hud.style.top = '8px';
+    s.hud.style.right = '8px';
+    s.hud.style.left = '';
+    s.hud.style.transform = '';
+    s.hud.style.flexDirection = 'row';
+    return;
+  }
+  s.hud.style.right = '';
+  s.hud.style.left = '50%';
+  s.hud.style.transform = 'translateX(-50%)';
+  s.hud.style.flexDirection = 'column';
   let topPx;
-  if (ui.shape.value === 'circle'){
+  if (shape === 'circle'){
     const edgeGap = Math.max(22*s.dpr,16);
     const outerR = Math.min(s.W,s.H)/2 - edgeGap;
     topPx = s.CY + outerR + 8*s.dpr;
@@ -109,6 +122,7 @@ function computeLevel(){
     s.ringsLeft = 0;
     s.elLayers.textContent = '0';
     s.bounceCount = 0; s.elBounces.textContent = '0';
+    resetBounceCount();
     s.elMsg.style.display='none';
     return;
   } else {
@@ -136,6 +150,7 @@ function computeLevel(){
   s.ringsLeft = (ui.shape.value==='circle' ? s.rings.length : s.lines.length);
   s.elLayers.textContent = String(s.ringsLeft);
   s.bounceCount = 0; s.elBounces.textContent = '0';
+  resetBounceCount();
   updateHudPosition();
 }
 

--- a/physics.js
+++ b/physics.js
@@ -51,7 +51,7 @@ export function processRingForBall_Circle(b, ring){
         elLayers.textContent = String(s.ringsLeft);
         if (s.ringsLeft===0){
           if (ui.autoRestart.checked){ globalThis.computeLevel(); return; }
-          else { s.launched=false; s.aiming=false; s.finished=true; s.elMsg.style.display='block'; }
+          else { s.launched=false; s.aiming=false; s.finished=true; }
         }
       }
       b.ringIndex++;
@@ -109,7 +109,7 @@ export function processRingForBall_Lines(b){
       elLayers.textContent = String(s.ringsLeft);
       if (s.ringsLeft===0){
         if (ui.autoRestart.checked){ globalThis.computeLevel(); return; }
-        else { s.launched=false; s.aiming=false; s.finished=true; s.elMsg.style.display='block'; }
+        else { s.launched=false; s.aiming=false; s.finished=true; }
       }
       if (ui.multi.checked && balls.length < MAX_BALLS){
         const speed = Math.hypot(b.vx,b.vy), ang=Math.atan2(b.vy,b.vx), d=0.14;

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,4 @@
-import { initAudio } from './audio.js';
+import { initAudio, resetBounceCount } from './audio.js';
 import { makeBall } from './physics.js';
 
 export const ui = {
@@ -124,6 +124,7 @@ export function resetToMenuState(){
   s.rings.length=0; s.lines.length=0; s.balls.length=0;
   s.ctx.clearRect(0,0,s.W,s.H); s.ptx.clearRect(0,0,s.W,s.H);
   s.elMsg.style.display='none'; s.bounceCount=0; s.elBounces.textContent='0'; s.elLayers.textContent='0';
+  resetBounceCount();
   try { if (s.audioCtx && s.audioCtx.state!=='closed') s.audioCtx.suspend(); } catch(e){}
 }
 


### PR DESCRIPTION
## Summary
- Display layers, bounces, reset, and menu controls in line mode HUD at top-right
- Reset audio bounce counter when starting or returning to menu to stop inflated counts
- Remove end-of-layer message text after last layer is cleared

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc8312c9388327a67aace29b1b5ed7